### PR TITLE
Make params in SearchApplicationClient optional

### DIFF
--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -1,7 +1,19 @@
-import Client from '../index'
+import SearchApplicationClient from '../index'
 
-describe('Client', () => {
-  test('should be defined', () => {
-    expect(Client).toBeDefined()
-  })
+describe('SearchApplicationClient', () => {
+    test('should throw error on missing application name', () => {
+        expect(() => SearchApplicationClient("", "", "")).toThrow(Error("applicationName is required"));
+    })
+
+    test('should throw error on missing endpoint', () => {
+        expect(() => SearchApplicationClient("application name", "", "")).toThrow(Error("endpoint is required"));
+    })
+
+    test('should throw error on missing apiKey', () => {
+        expect(() => SearchApplicationClient("application name", "endpoint", "")).toThrow(Error("apiKey is required"));
+    })
+
+    test('should not throw error on missing params', () => {
+        expect(() => SearchApplicationClient("application name", "endpoint", "api key")).not.toThrow();
+    })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export default function SearchApplicationClient(
   applicationName: string,
   endpoint: string,
   apiKey: string,
-  params: Record<string, any>
+  params?: Record<string, any>
 ): () => QueryBuilder {
   if (!applicationName) throwParamRequiredError('applicationName')
   if (!endpoint) throwParamRequiredError('endpoint')


### PR DESCRIPTION
The internal `Client` class seems to have two optional parameters `baseParams?` and `requestHeaders?`. The public API of `SearchApplicationClient` requires `params` to be present. As they're not checked if they're present and the underyling client doesn't require params I guess it makes more sense to adapt the `params` to be optional as this feels a bit inconvenient when using the client, but maybe I've got something wrong here.

I've also added missing tests for the `SearchApplicationClient` with this PR.