### PR TITLE
Fix query builder setting wrong parameter

### DIFF
--- a/src/__test__/functional/integration.test.ts
+++ b/src/__test__/functional/integration.test.ts
@@ -76,7 +76,7 @@ describe('Full integration test', () => {
                     ],
                   },
                 },
-                "query": "test",
+                "query_string": "test",
               },
             }
           `)
@@ -123,7 +123,7 @@ describe('Full integration test', () => {
                   },
                 },
                 "from": 0,
-                "query": "test",
+                "query_string": "test",
                 "size": 0,
               },
             }

--- a/src/__test__/query_builder.test.ts
+++ b/src/__test__/query_builder.test.ts
@@ -113,7 +113,7 @@ describe('QueryBuilder', () => {
     test('should add query to params', () => {
       queryBuilder.query('test')
       expect(queryBuilder.params).toEqual({
-        query: 'test',
+        query_string: 'test',
       })
     })
   })

--- a/src/query_builder.ts
+++ b/src/query_builder.ts
@@ -146,7 +146,7 @@ export class QueryBuilder {
    * @returns {QueryBuilder}
    */
   query(query: string): this {
-    return this.addParameter('query', query)
+    return this.addParameter('query_string', query)
   }
 
   /**


### PR DESCRIPTION
Probably related to https://github.com/elastic/search-application-client/issues/29

Current behavior: every query returns exactly the same result.

According to the 8.10 docs (https://www.elastic.co/guide/en/elasticsearch/reference/current/search-application-search.html) you need to use `query_string` as parameter and not `query`. Search applications actually don't throw an error, but simply return a result, which you'll get if you query without any parameters.